### PR TITLE
Merge 3-create-docker-compose into dev-docker

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,1 @@
+# Helm DBCore Docker subdirectory

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,42 @@
+services:
+
+    db:
+        image: postgres:17
+        environment:
+            POSTGRES_USER: root
+            POSTGRES_PASSWORD: root
+            POSTGRES_DB: dbcore
+        volumes:
+            - db-data:/var/lib/postgresql/data
+            - ../sql:/docker-entrypoint-initdb.d
+        ports:
+            - "5432:5432"
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U root"]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+        restart: unless-stopped
+
+    dal:
+        build: ../dal
+        container_name: dal
+        depends_on:
+            db:
+                condition: service_healthy          # Wait for Postgres to be ready
+        environment:
+            DB_HOST: db
+            DB_PORT: 5432
+            DB_USER: root
+            DB_PASS: root
+            DB_NAME: dbcore
+        ports:
+            - "50051:50051"                         # Expose DAL gRPC port
+        restart: unless-stopped
+
+volumes:
+    db-data:
+
+networks:
+    default:
+        driver: bridge


### PR DESCRIPTION
Creates docker compose that contains two services to run: db and dal. db runs the PostgreSQL 17 instance, and dal runs the DAL container and service.